### PR TITLE
Fix mobile responsiveness of 2024 page

### DIFF
--- a/app/pages/2024/index.mjs
+++ b/app/pages/2024/index.mjs
@@ -24,7 +24,7 @@ export default function ({ html /*state*/ }) {
         </section>
         <section id="teaser" class="landing">
           <h1>We're Back!</h1>
-          <p style="width:600px; text-align:left; margin:0 auto">
+          <p style="max-width:600px; text-align:left; margin:0 auto">
             CascadiaJS 2024 is coming BACK to Seattle, WA and will run from June
             19 - 22. We'll host a Welcome Reception on June 19, have 2 days of
             talks and workshops on June 20 and 21 and get out and about the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "enhance-app",
+  "name": "cascadiajs-website",
   "version": "4.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "enhance-app",
+      "name": "cascadiajs-website",
       "version": "4.0.4",
       "dependencies": {
         "@enhance/arc-plugin-enhance": "^9.1.3",


### PR DESCRIPTION
On mobile screens, the fixed width of the paragraph causes a horizontal scroll to read the paragraph. This PR updates the paragraph to use `max-width` instead of `width` so that on small screens the paragraph can have a width less than 600px.

Mobile screen:
| Before | After |
| --- | --- |
| <img width="547" alt="image" src="https://github.com/cascadiajs/cascadiajs/assets/459878/02e290c6-67db-4f7e-929c-8063b98ed2f9"> | <img width="553" alt="image" src="https://github.com/cascadiajs/cascadiajs/assets/459878/fee7f0bb-89af-4176-bda4-46dee1aa88e9"> |


PC screen:
| Before | After |
| --- | --- |
| <img width="1330" alt="image" src="https://github.com/cascadiajs/cascadiajs/assets/459878/0bad707e-98c2-43f6-9257-80de87d4348c"> | <img width="1080" alt="image" src="https://github.com/cascadiajs/cascadiajs/assets/459878/7ffb053d-96b4-4a58-ab54-87681e8ebe12"> |
