### PR TITLE
adds the boaf for day one to the connect site page

### DIFF
--- a/app/markdown/2025/connect.md
+++ b/app/markdown/2025/connect.md
@@ -5,21 +5,41 @@ Low-pressure ways to meet cool humans at CascadiaJS
 
 Whether you're a networking pro or prefer to keep things casual, CascadiaJS Connect offers opt-in ways to meet fellow attendees. No pressure, no awkwardness—just friendly ways to vibe, learn, and maybe not eat lunch alone.
 
+## Birds of a Feather (BOAF) Tables 🦜
+
+Join topic-based tables where you can connect with devs who share your interests. These informal discussion groups will be set up around Town Hall with 6-8 BoaF areas sprinkled throughout the space. Look for the 8.5" x 11" signs at each table to find your topic of interest.
+
+### Day 1 BoF Tables:
+
+**🤖 AI & Web Futures** - Talk about AI tools, LLMs in the browser, AI agents, edge compute, and what's next.
+
+**⚛️ React & Friends** - React, Vue, Svelte, Solid — share your love or gripes with modern frameworks.
+
+**🧪 Testing Made Fun** - Jest, Playwright, Vitest… plus your testing philosophy, wins, and woes.
+
+**📦 TypeScript & Tooling** - From typesafety to tooling drama: Deno, Bun, TSConfig mysteries, and more.
+
+**🐢 Performance & Optimization** - Side Projects Club - What are you building for fun? Come share ideas, stuck points, or wins.
+
+**♿ Accessibility & Inclusive Dev** - Share how you build for everyone, or learn what others are doing.
+
+**🌈 Career Growth & Transitions** (Community Table) - From junior to senior, manager paths, mentoring, and changing lanes.
+
+**🔍 Open Source & Community** - Maintainers, contributors, and the curious — let's talk collaboration.
+
+**🔮 Future of JavaScript** - Bring your predictions, hopes, and fears: WASM, AI, edge, and beyond.
+
+**🎲 Low-Key Games** - Play a quick game
+
+## "Talk to Me About..." Stickers 🏷️
+
+Add a conversation starter to your badge! Pick up stickers with prompts like "Talk to me about TypeScript" or "Ask me about my side project" to make starting conversations easier and more fun.
+
 ## Cascadia Connect: Pair Programming IRL! 🤝
 
 Whether you're coming to your first tech conference, flying solo, or just want to meet someone new, this light-touch pairing system helps you connect with another attendee based on shared vibes. No awkward icebreakers required.
 
 You may have signed up for this during registration or received an email about it. If you're matched, we'll share your name and email with your match so you can connect before the conference — maybe at the Welcome Reception (Sept 17), over coffee, or just to swap notes between talks.
-
-## Birds of a Feather (BOAF) Tables 🦜
-
-Join topic-based tables where you can connect with devs who share your interests. Whether you're into React, AI, accessibility, or something completely different, there's a table for you.
-
-These informal discussion groups will be set up around Town Hall with 6-8 BoaF areas sprinkled throughout the space. Look for the 8.5" x 11" signs at each table to find your topic of interest. These tables give you a chance to dive deep into your favorite technologies, share experiences, and learn from others who are passionate about the same things you are.
-
-## "Talk to Me About..." Stickers 🏷️
-
-Add a conversation starter to your badge! Pick up stickers with prompts like "Talk to me about TypeScript" or "Ask me about my side project" to make starting conversations easier and more fun.
 
 ## Low-Key Games 🎲
 


### PR DESCRIPTION
This PR reorganizes the connect page and adds what tables are available.