### PR TITLE
Fix GitHub URL formatting in talks.json

### DIFF
--- a/shared/data/2026/talks.json
+++ b/shared/data/2026/talks.json
@@ -124,7 +124,7 @@
       "company": "Expo",
       "location": "Palo Alto, CA USA",
       "social": [
-        { "type": "github", "url": "https://github.com/ide," },
+        { "type": "github", "url": "https://github.com/ide" },
         { "type": "x-twitter", "url": "https:/x.com/JI" }      ]
     }
   },  


### PR DESCRIPTION
removed a typo (an extra comma) from a URL that didn't work with the comma